### PR TITLE
Preserve SMMD pretrain iterator across epochs

### DIFF
--- a/model/GraphLoRA.py
+++ b/model/GraphLoRA.py
@@ -264,6 +264,7 @@ def transfer(args, config, gpu_id, is_reduction):
         scheduler = get_few_shot_scheduler(optimizer, args.num_epochs)
 
     pretrain_graph_loader = DataLoader(pretrain_dataset.x, batch_size=32, shuffle=True)
+    pretrain_graph_iter = None
 
     max_acc, max_test_acc, max_epoch = 0.0, 0.0, 0
     for epoch in range(0, args.num_epochs):
@@ -281,7 +282,14 @@ def transfer(args, config, gpu_id, is_reduction):
 
         optimizer.zero_grad()
 
-        smmd_loss_f = batched_smmd_loss(feature_map, pretrain_graph_loader, SMMD, ppr_weight, 32)
+        smmd_loss_f, pretrain_graph_iter = batched_smmd_loss(
+            feature_map,
+            pretrain_graph_loader,
+            SMMD,
+            ppr_weight,
+            32,
+            data_iter=pretrain_graph_iter,
+        )
         ct_loss = 0.5 * (
             batched_gct_loss(emb1, emb2, 1000, mask, args.tau) +
             batched_gct_loss(emb2, emb1, 1000, mask, args.tau)

--- a/util.py
+++ b/util.py
@@ -152,21 +152,58 @@ def batched_gct_loss(z1: torch.Tensor, z2: torch.Tensor, batch_size: int, mask, 
     return torch.cat(losses)
 
 
-def batched_smmd_loss(z1: torch.Tensor, z2, MMD, ppr_weight, batch_size):
-# 每次循环里都重新构造了一个迭代器 iter(z2)，然后 next(...) 只会取同一份第一批数据。这会让 SMMD 只对齐到 z2 的“那一小撮样本”，对齐严重偏置，对齐失败或过拟合到这小批；
+def batched_smmd_loss(z1: torch.Tensor, z2, MMD, ppr_weight, batch_size, data_iter=None):
+    """Compute SMMD loss in batches while iterating sequentially over z2.
+
+    Parameters
+    ----------
+    z1 : torch.Tensor
+        Node representations of the downstream graph.
+    z2 : Iterable or torch.utils.data.DataLoader
+        Pretraining representations that will be iterated over.
+    MMD : Callable
+        Loss function used to compute the SMMD objective.
+    ppr_weight : torch.Tensor
+        Personalized PageRank weights used for reweighting the loss.
+    batch_size : int
+        Batch size for iterating over ``z1``.
+    data_iter : iterator, optional
+        Persistent iterator over ``z2``. Passing back the iterator between
+        calls avoids reusing the first batch after every invocation.
+
+    Returns
+    -------
+    tuple[torch.Tensor, iterator]
+        The mean SMMD loss for this call and the (potentially updated)
+        iterator that should be reused on the next invocation.
+    """
+
     device = z1.device
     num_nodes = z1.size(0)
     num_batches = (num_nodes - 1) // batch_size + 1
-    indices = torch.arange(0, num_nodes).to(device)
+    indices = torch.arange(0, num_nodes, device=device)
     losses = []
+
+    if data_iter is None:
+        data_iter = iter(z2)
 
     for i in range(num_batches):
         mask = indices[i * batch_size:(i + 1) * batch_size]
         ppr = ppr_weight[mask][:, mask]
-        target = next(iter(z2))
+
+        try:
+            target = next(data_iter)
+        except StopIteration:
+            data_iter = iter(z2)
+            target = next(data_iter)
+
+        if isinstance(target, (list, tuple)):
+            target = target[0]
+
+        target = target.to(device, non_blocking=True)
         losses.append(MMD(z1[mask], target, ppr))
 
-    return torch.stack(losses).mean()
+    return torch.stack(losses).mean(), data_iter
 
 
 def get_few_shot_mask(data, shot, dataname, device):


### PR DESCRIPTION
## Summary
- allow `batched_smmd_loss` to accept and return a persistent iterator so pretraining batches continue across calls
- store the iterator in the GraphLoRA transfer loop to avoid reusing the same pretraining batch each epoch and handle tuple batches safely

## Testing
- python -m compileall util.py model/GraphLoRA.py

------
https://chatgpt.com/codex/tasks/task_e_68da39e29ce08332869d786fae106da1