### PR TITLE
Reset SMMD loader iterator per call

### DIFF
--- a/model/GraphLoRA.py
+++ b/model/GraphLoRA.py
@@ -281,7 +281,13 @@ def transfer(args, config, gpu_id, is_reduction):
 
         optimizer.zero_grad()
 
-        smmd_loss_f = batched_smmd_loss(feature_map, pretrain_graph_loader, SMMD, ppr_weight, 32)
+        smmd_loss_f = batched_smmd_loss(
+            feature_map,
+            pretrain_graph_loader,
+            SMMD,
+            ppr_weight,
+            32,
+        )
         ct_loss = 0.5 * (
             batched_gct_loss(emb1, emb2, 1000, mask, args.tau) +
             batched_gct_loss(emb2, emb1, 1000, mask, args.tau)

--- a/model/GraphLoRA.py
+++ b/model/GraphLoRA.py
@@ -264,6 +264,7 @@ def transfer(args, config, gpu_id, is_reduction):
         scheduler = get_few_shot_scheduler(optimizer, args.num_epochs)
 
     pretrain_graph_loader = DataLoader(pretrain_dataset.x, batch_size=32, shuffle=True)
+    pretrain_graph_iter = None
 
     max_acc, max_test_acc, max_epoch = 0.0, 0.0, 0
     for epoch in range(0, args.num_epochs):
@@ -281,12 +282,13 @@ def transfer(args, config, gpu_id, is_reduction):
 
         optimizer.zero_grad()
 
-        smmd_loss_f = batched_smmd_loss(
+        smmd_loss_f, pretrain_graph_iter = batched_smmd_loss(
             feature_map,
             pretrain_graph_loader,
             SMMD,
             ppr_weight,
             32,
+            iterator=pretrain_graph_iter,
         )
         ct_loss = 0.5 * (
             batched_gct_loss(emb1, emb2, 1000, mask, args.tau) +

--- a/util.py
+++ b/util.py
@@ -153,17 +153,28 @@ def batched_gct_loss(z1: torch.Tensor, z2: torch.Tensor, batch_size: int, mask, 
 
 
 def batched_smmd_loss(z1: torch.Tensor, z2, MMD, ppr_weight, batch_size):
-# 每次循环里都重新构造了一个迭代器 iter(z2)，然后 next(...) 只会取同一份第一批数据。这会让 SMMD 只对齐到 z2 的“那一小撮样本”，对齐严重偏置，对齐失败或过拟合到这小批；
+    """Compute SMMD loss in batches while walking sequentially over z2."""
     device = z1.device
     num_nodes = z1.size(0)
     num_batches = (num_nodes - 1) // batch_size + 1
     indices = torch.arange(0, num_nodes).to(device)
     losses = []
 
+    data_iter = iter(z2)
+
     for i in range(num_batches):
         mask = indices[i * batch_size:(i + 1) * batch_size]
         ppr = ppr_weight[mask][:, mask]
-        target = next(iter(z2))
+        try:
+            target = next(data_iter)
+        except StopIteration:
+            data_iter = iter(z2)
+            target = next(data_iter)
+
+        if isinstance(target, (list, tuple)):
+            target = target[0]
+
+        target = target.to(device, non_blocking=True)
         losses.append(MMD(z1[mask], target, ppr))
 
     return torch.stack(losses).mean()


### PR DESCRIPTION
## Summary
- initialize a local iterator inside `batched_smmd_loss` so every call walks the pretraining loader once before reshuffling
- revert the GraphLoRA transfer loop to consume the scalar SMMD loss returned by the helper

## Testing
- python -m compileall util.py model/GraphLoRA.py

------
https://chatgpt.com/codex/tasks/task_e_68da39e29ce08332869d786fae106da1